### PR TITLE
Change "low power" indicator to be a blinking red LED

### DIFF
--- a/BlueToothLedSign.ino
+++ b/BlueToothLedSign.ino
@@ -87,7 +87,7 @@ void setup() {
 // This metod is called continously.
 void loop()
 {  
-  emitTelemetry();
+  //emitTelemetry();
   checkForLowPowerState();
 
   if (inLowPowerMode) {

--- a/BlueToothLedSign.ino
+++ b/BlueToothLedSign.ino
@@ -87,7 +87,7 @@ void setup() {
 // This metod is called continously.
 void loop()
 {  
-  //emitTelemetry();
+  emitTelemetry();
   checkForLowPowerState();
 
   if (inLowPowerMode) {

--- a/BlueToothLedSign.ino
+++ b/BlueToothLedSign.ino
@@ -14,11 +14,11 @@
 #define VOLTAGEINPUTPIN 14    // The pin # for the analog input to detect battery voltage level.
 
 // Initial default values for LED styles
-#define DEFAULTSTYLE 1        // The default style to start with. This is an index into the lightStyles vector.
+#define DEFAULTSTYLE 0        // The default style to start with. This is an index into the lightStyles vector.
 #define DEFAULTBRIGHTNESS 255 // Brightness should be between 0 and 255.
-#define DEFAULTSPEED 50       // Speed should be between 1 and 100.
-#define DEFAULTSTEP  50       // Step should be between 1 and 100.
-#define DEFAULTPATTERN 0      // Default patern (ie, Row/Column/Digit/etc). This is an index into the LightStyle::knownPatterns vector.
+#define DEFAULTSPEED 100       // Speed should be between 1 and 100.
+#define DEFAULTSTEP  100       // Step should be between 1 and 100.
+#define DEFAULTPATTERN 6      // Default patern (ie, Row/Column/Digit/etc). This is an index into the LightStyle::knownPatterns vector.
 
 // Batter power monitoring
 #define LOWPOWERTHRESHOLD 6.0     // The voltage below which the system will go into "low power" mode.

--- a/Bluetooth.cpp
+++ b/Bluetooth.cpp
@@ -10,12 +10,9 @@ void Bluetooth::initialize() {
     Serial.println("BLE initialization failed!");
   }
 
-  BLE.debug(Serial);
-
   BLE.setLocalName("3181 LED Controller");
   BLE.setAdvertisedService(m_ledService);
   m_ledService.addCharacteristic(m_brightnessCharacteristic);
-  m_brightnessCharacteristic.setEventHandler(BLEWritten, brightnessCharacteristicWritten);
   m_ledService.addCharacteristic(m_styleCharacteristic);
   m_ledService.addCharacteristic(m_styleNamesCharacteristic);
   m_ledService.addCharacteristic(m_speedCharacteristic);
@@ -114,7 +111,6 @@ void Bluetooth::emitBatteryVoltage(float voltage) {
 }
 
 byte Bluetooth::readByteFromCharacteristic(BLEByteCharacteristic characteristic, byte defaultValue, String name) {
-  //BLEDevice central = BLE.central();
   if (BLE.connected()) {
     if (characteristic.written()) {
       Serial.print("Reading new value for ");
@@ -139,13 +135,4 @@ String* Bluetooth::joinStrings(std::vector<String> strings) {
   }
 
   return joinedStrings;
-}
-
-void Bluetooth::brightnessCharacteristicWritten(BLEDevice central, BLECharacteristic characteristic)
-{
-  Serial.print("In characteristic callback. ");
-  uint8_t valByte;
-  characteristic.readValue(valByte);
-  Serial.print("Byte received: ");
-  Serial.println(valByte, HEX);
 }

--- a/Bluetooth.cpp
+++ b/Bluetooth.cpp
@@ -10,9 +10,12 @@ void Bluetooth::initialize() {
     Serial.println("BLE initialization failed!");
   }
 
+  BLE.debug(Serial);
+
   BLE.setLocalName("3181 LED Controller");
   BLE.setAdvertisedService(m_ledService);
   m_ledService.addCharacteristic(m_brightnessCharacteristic);
+  m_brightnessCharacteristic.setEventHandler(BLEWritten, brightnessCharacteristicWritten);
   m_ledService.addCharacteristic(m_styleCharacteristic);
   m_ledService.addCharacteristic(m_styleNamesCharacteristic);
   m_ledService.addCharacteristic(m_speedCharacteristic);
@@ -111,8 +114,8 @@ void Bluetooth::emitBatteryVoltage(float voltage) {
 }
 
 byte Bluetooth::readByteFromCharacteristic(BLEByteCharacteristic characteristic, byte defaultValue, String name) {
-  BLEDevice central = BLE.central();
-  if (central) {
+  //BLEDevice central = BLE.central();
+  if (BLE.connected()) {
     if (characteristic.written()) {
       Serial.print("Reading new value for ");
       Serial.print(name);
@@ -136,4 +139,13 @@ String* Bluetooth::joinStrings(std::vector<String> strings) {
   }
 
   return joinedStrings;
+}
+
+void Bluetooth::brightnessCharacteristicWritten(BLEDevice central, BLECharacteristic characteristic)
+{
+  Serial.print("In characteristic callback. ");
+  uint8_t valByte;
+  characteristic.readValue(valByte);
+  Serial.print("Byte received: ");
+  Serial.println(valByte, HEX);
 }

--- a/Bluetooth.h
+++ b/Bluetooth.h
@@ -48,6 +48,8 @@ class Bluetooth {
 
     String* joinStrings(std::vector<String> strings);
     byte readByteFromCharacteristic(BLEByteCharacteristic characteristic, byte defaultValue, String name);
+
+    static void brightnessCharacteristicWritten(BLEDevice central, BLECharacteristic characteristic);
 };
 
 #endif

--- a/Bluetooth.h
+++ b/Bluetooth.h
@@ -48,8 +48,6 @@ class Bluetooth {
 
     String* joinStrings(std::vector<String> strings);
     byte readByteFromCharacteristic(BLEByteCharacteristic characteristic, byte defaultValue, String name);
-
-    static void brightnessCharacteristicWritten(BLEDevice central, BLECharacteristic characteristic);
 };
 
 #endif


### PR DESCRIPTION
Instead of just shutting off all LEDs, display one blinking red LED as an indication that the power is too low.
Also changing the default style at power-on to be rainbow.